### PR TITLE
Replace wget URL with latest release URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Quoting [bkeepers/dotenv][dotenv]:
 Download `shdotenv` (shell script) from [releases](https://github.com/ko1nksm/shdotenv/releases).
 
 ```console
-$ wget https://github.com/ko1nksm/shdotenv/releases/download/[TAG]/shdotenv -O $HOME/bin/shdotenv
+$ wget https://github.com/ko1nksm/shdotenv/releases/latest/download/shdotenv -O $HOME/bin/shdotenv
 $ chmod +x $HOME/bin/shdotenv
 ```
 


### PR DESCRIPTION
Not sure if you want to do this, but I changed the link to the "latest" release of shdotenv.  Even after releasing a new version, the link will always go to the latest release.

Great job on this!