### PR TITLE
Added a simple php output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Options:
                                 posix, ruby, node, python,
                                 php, go, rust, docker
   -f, --format FORMAT       Output in the specified format [default: sh]
-                                sh, csh, fish, json, jsonl, yaml, name
+                                sh, csh, fish, json, jsonl, yaml, name, php
   -e, --env ENV_PATH        Location of the .env file [default: .env]
                               Multiple -e options are allowed
                               If the ENV_PATH is "-", read from stdin

--- a/src/parser.awk
+++ b/src/parser.awk
@@ -159,6 +159,7 @@ function output(flag, key, value) {
   if (FORMAT == "json") output_json(flag, key, value)
   if (FORMAT == "jsonl") output_jsonl(flag, key, value)
   if (FORMAT == "yaml") output_yaml(flag, key, value)
+  if (FORMAT == "php") output_php(flag, key, value)
   if (FORMAT == "name") output_name_only(flag, key, value)
 }
 
@@ -217,6 +218,19 @@ function output_jsonl(flag, key, value) {
 function output_yaml(flag, key, value) {
   if (flag == ONLY_EXPORT || flag == DO_EXPORT || flag == NO_EXPORT) {
     printf "%s: \"%s\"\n", key, json_escape(value)
+  }
+}
+
+function output_php(flag, key, value) {
+  if (flag == BEFORE_ALL) {
+    print "<?php\n"
+    print "function __local_env() {"
+    print "  $env = [];"
+  } else if (flag == AFTER_ALL) {
+    printf "\n  return $env;\n"
+    printf "}\n"
+  } else if (flag == ONLY_EXPORT || flag == DO_EXPORT || flag == NO_EXPORT) {
+    printf "  $env[\"%s\"] = \"%s\"\n", key, json_escape(value)
   }
 }
 
@@ -357,7 +371,7 @@ BEGIN {
   }
 
   if (FORMAT == "") FORMAT = "sh"
-  if (!match(FORMAT, "^(sh|csh|fish|json|jsonl|yaml|name)$")) {
+  if (!match(FORMAT, "^(sh|csh|fish|json|jsonl|yaml|php|name)$")) {
     abort("unsupported format: " FORMAT)
   }
 

--- a/src/parser.awk
+++ b/src/parser.awk
@@ -230,7 +230,7 @@ function output_php(flag, key, value) {
     printf "\n  return $env;\n"
     printf "}\n"
   } else if (flag == ONLY_EXPORT || flag == DO_EXPORT || flag == NO_EXPORT) {
-    printf "  $env[\"%s\"] = \"%s\"\n", key, json_escape(value)
+    printf "  $env[\"%s\"] = \"%s\";\n", key, json_escape(value)
   }
 }
 


### PR DESCRIPTION
A use-case which I find very useful is to add a php output format.

This allows users to generate a simple php file, that can be included into existing projects which eliminates the need to vlucas/dotenv and marginally improves performance since the .env files are not parsed at every http request.

 